### PR TITLE
Use path provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,14 @@
 [[package]]
+name = "glob"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "ncount"
 version = "0.1.2"
+dependencies = [
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
+[metadata]
+"checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.2"
 authors = ["J/A <archer884@gmail.com>"]
 
 [dependencies]
+glob = "*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,15 @@
+extern crate glob;
+
+mod path;
 mod split_words;
 mod stats;
 
 use stats::Stats;
-use std::env;
+use path::PathProvider;
 
 fn main() {
     let mut total_words = 0;
-    for path in env::args().skip(1) {
+    for path in PathProvider::new() {
         if let Ok(stats) = Stats::from_path(path) {
             total_words += stats.words();
             println!("{}", stats);

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,0 +1,60 @@
+use glob::Paths;
+use glob::glob as deglob;
+use std::env::{self, Args};
+use std::path::PathBuf;
+use std::iter::Skip;
+
+pub struct PathProvider {
+    args: Skip<Args>,
+    glob: Option<Paths>,
+}
+
+impl PathProvider {
+    pub fn new() -> Self {
+        Self {
+            args: env::args().skip(1),
+            glob: None
+        }
+    }
+
+    fn next_globbed_path(&mut self) -> Option<PathBuf> {
+        let candidate = self.glob.as_mut().and_then(|glob| glob.next());
+        if let Some(Ok(path)) = candidate {
+            return Some(path);
+        }
+
+        self.glob = None;
+        None
+    }
+}
+
+impl Iterator for PathProvider {
+    type Item = PathBuf;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.next_globbed_path() {
+
+            // No globbed paths available.
+            None => match self.args.next() {
+                None => None,
+                Some(arg) => if arg.contains(glob_char) {
+                    self.glob = deglob(&arg).ok();
+                    self.next()
+                } else {
+                    Some(arg.into())
+                },
+            },
+
+            // Return globbed path.
+            path => path,
+            
+        }
+    }
+}
+
+fn glob_char(c: char) -> bool {
+    match c {
+        '*' | '?' | '[' => true,
+        _ => false,
+    }
+}

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::io;
+use std::path::Path;
 
 pub struct Stats {
     path: String,
@@ -9,7 +10,7 @@ pub struct Stats {
 }
 
 impl Stats {
-    pub fn from_path<T: Into<String>>(path: T) -> io::Result<Self> {
+    pub fn from_path<T: AsRef<Path>>(path: T) -> io::Result<Self> {
         use split_words::SplitWords;
         use std::cmp;
         use std::fs::File;
@@ -36,11 +37,9 @@ impl Stats {
             })
         }
 
-        let path = path.into();
         let file = BufReader::new(File::open(&path)?);
-
         let mut stats = Stats {
-            path,
+            path: format!("{}", path.as_ref().display()),
             words: 0,
             paragraphs: 0,
             longest_paragraph: 0,


### PR DESCRIPTION
The `PathProvider` abstraction provides stable path globbing behavior on disparate systems by detecting globbed paths in command line arguments and deglobbing said paths before passing them on for processing.

tl;dr: `ncount src/*` now works on Windows the way it does on macOS.