### PR TITLE
Print stats per section rather than per file

### DIFF
--- a/src/lex.rs
+++ b/src/lex.rs
@@ -1,0 +1,84 @@
+use std::io::{BufRead, Result};
+use regex::Regex;
+
+#[derive(Debug)]
+pub enum Lexeme {
+    Heading(String),
+    Paragraph(String),
+}
+
+pub struct Lexemes<'a, T> {
+    lexer: &'a Lexer,
+    text: T,
+}
+
+impl<'a, T: BufRead> Iterator for Lexemes<'a, T> {
+    type Item = Result<Lexeme>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let mut buf = String::new();
+            match self.text.read_line(&mut buf) {
+                Err(e) => return Some(Err(e)),
+                Ok(0) => return None,
+                Ok(_) => if let Some(lexeme) = self.lexer.from_string(buf) {
+                    return Some(Ok(lexeme));
+                } else {
+                    continue;
+                },
+            }
+        }
+    }
+}
+
+pub struct Lexer {
+    comments: Regex,
+}
+
+impl Lexer {
+    pub fn new() -> Self {
+        let comments = Regex::new(r#"<[^<]*>"#).expect("Failed to initialize comment pattern");
+
+        Self { comments }
+    }
+
+    pub fn lexemes<'a, R: 'a>(&'a self, text: R) -> Lexemes<'a, R>
+    where
+        R: BufRead,
+    {
+        Lexemes {
+            lexer: self,
+            text: text,
+        }
+    }
+
+    fn from_string(&self, s: String) -> Option<Lexeme> {
+        let s = self.comments.replace(&s, "");
+        if s.trim().is_empty() {
+            return None;
+        }
+
+        if s.starts_with('#') {
+            return Some(Lexeme::Heading(s.into()));
+        }
+
+        if is_valid_line(&s) {
+            return Some(Lexeme::Paragraph(s.into()));
+        }
+
+        return None;
+    }
+}
+
+// Ignore anything that's not text. Text can start with these legal characters.
+fn is_valid_line(s: &str) -> bool {
+    !s.is_empty() && s.starts_with(|c| {
+        c == '"'        // Dialog
+        || c == '.'     // Ellipsis
+        || c == '*'     // Italics
+        || {
+            let c = (c as u8) & !32;
+            c >= b'A' && c <= b'Z'
+        }
+    })
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,24 @@
 extern crate glob;
 extern crate regex;
 
+mod lex;
 mod path;
 mod split_words;
 mod stats;
 
 use path::PathProvider;
-use stats::StatsCollector;
+use stats::Collector;
+use std::process;
 
 fn main() {
-    let mut collector = StatsCollector::new();
+    let mut collector = Collector::new();
+
     for path in PathProvider::new() {
-        if let Ok(stats) = collector.from_path(path) {
-            println!("{}", stats);
+        if let Err(e) = collector.push_path(path) {
+            eprintln!("{}", e);
+            process::exit(1);
         }
     }
 
-    println!("{}", collector.total_words());
+    println!("{}", collector);
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,112 +1,122 @@
-use regex::Regex;
-use std::fmt::{self, Display};
-use std::io;
+use lex::{Lexeme, Lexer};
+use split_words::SplitWords;
+use std::fmt;
+use std::io::{BufReader, Result};
 use std::path::Path;
 
-pub struct StatsCollector {
-    comments: Regex,
-    total_words: u32,
-}
-
-impl StatsCollector {
-    pub fn new() -> Self {
-        Self {
-            comments: Regex::new(r#"<[^<]*>"#).expect("Failed to initialize comment pattern"),
-            total_words: 0,
-        }
-    }
-
-    pub fn from_path<T: AsRef<Path>>(&mut self, path: T) -> io::Result<Stats> {
-        use std::fs::File;
-        use std::io::{BufReader, Read};
-        
-        let buffer = {
-            let mut buf = String::new();
-            let _ = File::open(&path).map(BufReader::new)?.read_to_string(&mut buf);
-            buf
-        };
-
-        let buffer = self.comments.replace(&buffer, "");
-        let stats = Stats::from_buffer(path.as_ref().display(), &buffer);
-
-        self.total_words += stats.words;
-        Ok(stats)
-    }
-
-    pub fn total_words(&self) -> u32 {
-        self.total_words
-    }
-}
-
+#[derive(Debug, Default)]
 pub struct Stats {
-    path: String,
     words: u32,
     paragraphs: u32,
     longest_paragraph: u32,
 }
 
 impl Stats {
-    pub fn from_buffer<T: Display>(name: T, s: &str) -> Self {
-        use split_words::SplitWords;
+    fn is_empty(&self) -> bool {
+        self.words == 0 && self.paragraphs == 0 && self.longest_paragraph == 0
+    }
+
+    fn apply(&mut self, s: &str) {
         use std::cmp;
-        
-        // Ignore anything that's not text. Text can start with these legal characters.
-        fn is_valid_line(s: &str) -> bool {
-            !s.is_empty() && s.starts_with(|c| {
-                c == '"'        // Dialog
-                || c == '.'     // Ellipsis
-                || c == '*'     // Italics
-                || {
-                    let c = (c as u8) & !32;
-                    c >= b'A' && c <= b'Z'
-                }
-            })
+
+        let words = s.split_words().count() as u32;
+        self.longest_paragraph = cmp::max(words, self.longest_paragraph);
+        self.paragraphs += 1;
+        self.words += words;
+    }
+}
+
+pub struct Collector {
+    lexer: Lexer,
+    headings: Vec<(String, Stats)>,
+    total_words: u32,
+    max_heading_width: usize,
+}
+
+impl Collector {
+    pub fn new() -> Self {
+        Collector {
+            lexer: Lexer::new(),
+            headings: Vec::new(),
+            total_words: 0,
+            max_heading_width: 0,
+        }
+    }
+
+    pub fn push_path<T: AsRef<Path>>(&mut self, path: T) -> Result<()> {
+        use std::cmp;
+        use std::fs::File;
+
+        fn format_heading(heading: &str) -> String {
+            heading.trim_left_matches(|c| c == '#').trim().into()
         }
 
-        let mut stats = Stats {
-            path: format!("{}", name),
-            words: 0,
-            paragraphs: 0,
-            longest_paragraph: 0,
-        };
+        let file = File::open(path).map(BufReader::new)?;
+        let lexemes = self.lexer.lexemes(file);
 
-        for line in s.lines() {
-            if is_valid_line(line) {
-                let words = line.split_words().count() as u32;
-                stats.longest_paragraph = cmp::max(words, stats.longest_paragraph);
-                stats.paragraphs += 1;
-                stats.words += words;
+        let mut section = None;
+        let mut stats = Stats::default();
+
+        for lexeme in lexemes {
+            match lexeme {
+                Err(e) => return Err(e),
+
+                Ok(Lexeme::Heading(heading)) => match section.take() {
+                    None => section = Some(format_heading(&heading)),
+                    Some(previous_section) => {
+                        self.headings.push((previous_section, stats));
+                        section = Some(heading);
+                        stats = Stats::default();
+                    }
+                },
+
+                Ok(Lexeme::Paragraph(paragraph)) => stats.apply(&paragraph),
             }
         }
 
-        stats
+        if !stats.is_empty() {
+            self.max_heading_width = section
+                .as_ref()
+                .map(|heading| cmp::max(self.max_heading_width, heading.len()))
+                .unwrap_or(0);
+
+            self.total_words += stats.words;
+            self.headings
+                .push((section.unwrap_or_else(|| String::from("unknown")), stats));
+        }
+
+        Ok(())
     }
 }
 
-impl fmt::Display for Stats {
+impl fmt::Display for Collector {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use std::path::Path;
+        fn derive_width(width: usize) -> usize {
+            // Leave at least one blank
+            let width = width + 1;
+            width + width % 4
+        }
 
-        let path: &Path = self.path.as_ref();
-        let filename = path.file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or("unknown");
+        fn average_paragraph(stats: &Stats) -> u32 {
+            match stats.paragraphs {
+                0 => stats.words,
+                n => stats.words / n,
+            }
+        }
 
-        write!(
-            f,
-            "{}\t{}\t{}\t({} / {})",
-            filename,
-            self.words,
-            self.paragraphs,
-            average(self.words, self.paragraphs),
-            self.longest_paragraph
-        )
-    }
-}
+        for (ref heading, ref stats) in &self.headings {
+            writeln!(
+                f,
+                "{:width$}{:5}{:5}{:5}{:4}",
+                heading,
+                stats.words,
+                stats.paragraphs,
+                average_paragraph(stats),
+                stats.longest_paragraph,
+                width = derive_width(self.max_heading_width)
+            )?;
+        }
 
-fn average(left: u32, right: u32) -> u32 {
-    match right {
-        0 => 0,
-        _ => left / right,
+        writeln!(f, "\nTotal words: {}", self.total_words)
     }
 }


### PR DESCRIPTION
We didn't quite get all the way to printing chapter stats, but we now have stats per section, and we're formatting section names instead of spewing filenames to the screen. Pretty nice, I think.

I also dug into the docs on std::fmt and found some interestingly useful tidbits about padding so that we can actually do padding at runtime for a change.